### PR TITLE
feat(api): add Category read endpoints

### DIFF
--- a/Projeto-SPA.Api/Endpoints/V1/CategoryEndpoints.cs
+++ b/Projeto-SPA.Api/Endpoints/V1/CategoryEndpoints.cs
@@ -1,4 +1,7 @@
-﻿namespace Projeto_SPA.Api.Endpoints.V1
+﻿using Microsoft.EntityFrameworkCore;
+using Projeto_SPA.Api.Data;
+
+namespace Projeto_SPA.Api.Endpoints.V1
 {
     public static class CategoryEndpoints
     {
@@ -6,10 +9,20 @@
         {
             var map = app.MapGroup("/api/v1/categories");
 
-            map.MapGet("", () => Results.Ok(new[] { "Category 1", "Category 2" }))
-                .WithTags("Categories")
-                .WithSummary("Returns all test categories")
-                .WithDescription("This endpoints returns dummy categories only for Swagger test");
+            map.MapGet("", async (AppDbContext db) =>
+            {
+                var categories = await db.Categories.ToListAsync();
+                return Results.Ok(categories);
+            });
+
+            map.MapGet("/{id}", async (int id, AppDbContext db) =>
+            {
+                var category = await db.Categories.FindAsync(id);
+                if(category == null) 
+                    return Results.NotFound();
+
+                return Results.Ok(category);
+            });
         }
     }
 }

--- a/Projeto-SPA.Api/Program.cs
+++ b/Projeto-SPA.Api/Program.cs
@@ -28,13 +28,6 @@ app.UseHttpsRedirection();
 app.MapProductEndpoints();
 app.MapCategoryEndpoints();
 
-app.MapGet("/debug/db", async (AppDbContext db) =>
-{
-    return await db.Database.CanConnectAsync()
-        ? Results.Ok("Database connection successful!")
-        : Results.Problem("Failed to connect to the database.");
-});
-
 app.Run();
 
 


### PR DESCRIPTION
# PR Title
feat(api): add Category read endpoints

# Description

## Context
<!-- Explain the reason for this change -->
- Enable read-only access to Categories through the API.
- Prepare the system for future endpoints (Products, CRUD operations).

## What was done
- Added `GET /api/v1/categories` to return all categories.
- Added `GET /api/v1/categories/{id}` to return a single category or 404 if not found.
- Integrated endpoints into the V1 Minimal API structure.

## How to test
- Run the application locally.
- Access the endpoint:
 - `GET /api/v1/categories` → should return a list of all categories.
 - `GET /api/v1/categories/{id}` → should return the specific category if it exists, otherwise 404.

## Related issue
Closes #11 

## Notes
- No validation, authentication, or authorization included; these will be addressed in future milestones.
- Endpoints are designed to be consumed by Blazor or other future clients.