### PR TITLE
feat(api): add Product read endpoints

### DIFF
--- a/Projeto-SPA.Api/Endpoints/V1/CategoryEndpoints.cs
+++ b/Projeto-SPA.Api/Endpoints/V1/CategoryEndpoints.cs
@@ -11,17 +11,17 @@ namespace Projeto_SPA.Api.Endpoints.V1
 
             map.MapGet("", async (AppDbContext db) =>
             {
-                var categories = await db.Categories.ToListAsync();
-                return Results.Ok(categories);
+                var result = await db.Categories.ToListAsync();
+                return Results.Ok(result);
             });
 
             map.MapGet("/{id}", async (int id, AppDbContext db) =>
             {
-                var category = await db.Categories.FindAsync(id);
-                if(category == null) 
+                var result = await db.Categories.FindAsync(id);
+                if(result == null) 
                     return Results.NotFound();
 
-                return Results.Ok(category);
+                return Results.Ok(result);
             });
         }
     }

--- a/Projeto-SPA.Api/Endpoints/V1/ProductEndpoints.cs
+++ b/Projeto-SPA.Api/Endpoints/V1/ProductEndpoints.cs
@@ -1,4 +1,8 @@
-﻿namespace Projeto_SPA.Api.Endpoints.V1
+﻿using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
+using Projeto_SPA.Api.Data;
+
+namespace Projeto_SPA.Api.Endpoints.V1
 {
     public static class ProductEndpoints
     {
@@ -6,10 +10,20 @@
         {
             var map = app.MapGroup("api/v1/products");
 
-            map.MapGet("", () => Results.Ok(new[] { "Product 1", "Product 2" }))
-                .WithTags("Products")
-                .WithSummary("Returns all test products")
-                .WithDescription("This endpoints returns dummy products only for Swagger test");
+            map.MapGet("", async (AppDbContext db) => 
+            { 
+                var result = await db.Products.ToListAsync();
+                return Results.Ok(result);
+            });
+
+            map.MapGet("/{id}", async (int id, AppDbContext db) =>
+            {
+                var result = await db.Products.FindAsync(id);
+                if (result == null)
+                    return Results.NotFound();
+
+                return Results.Ok(result);
+            });
         }
     }
 }


### PR DESCRIPTION
# PR Title
feat(api): add Product read endpoints

# Description

## Context
- Enable read-only access to Products through the API.
- Prepare the system for future endpoints (CRUD operations).

## What was done
- Added `GET /api/v1/products` to return all categories.
- Added `GET /api/v1/products/{id}` to return a single category or 404 if not found.
- Integrated endpoints into the V1 Minimal API structure.

## How to test
- Run the application locally.
- Access the endpoint:
  - `GET /api/v1/products` → should return a list of all categories.
  - `GET /api/v1/products/{id}` → should return the specific category if it exists, otherwise 404.

## Related issue
Closes #12 

## Notes
- No validation, authentication, or authorization included; these will be addressed in future milestones.
- Endpoints are designed to be consumed by Blazor or other future clients.