### PR TITLE
feat(api): introduce request and response DTOs for categories and products

### DIFF
--- a/Projeto-SPA.Api/Contracts/V1/Categories/CategoryResponse.cs
+++ b/Projeto-SPA.Api/Contracts/V1/Categories/CategoryResponse.cs
@@ -1,0 +1,9 @@
+﻿namespace Projeto_SPA.Api.Contracts.V1.Categories
+{
+    public class CategoryResponse
+    {
+        public int Id { get; set; }
+
+        public string Title { get; set; } = null!;
+    }
+}

--- a/Projeto-SPA.Api/Contracts/V1/Categories/CreateCategoryRequest.cs
+++ b/Projeto-SPA.Api/Contracts/V1/Categories/CreateCategoryRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace Projeto_SPA.Api.Contracts.V1.Categories
+{
+    public class CreateCategoryRequest
+    {
+        public required string Title { get; set; }
+    }
+}

--- a/Projeto-SPA.Api/Contracts/V1/Categories/UpdateCategoryRequest.cs
+++ b/Projeto-SPA.Api/Contracts/V1/Categories/UpdateCategoryRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace Projeto_SPA.Api.Contracts.V1.Categories
+{
+    public class UpdateCategoryRequest
+    {
+        public required string Title { get; set; }
+    }
+}

--- a/Projeto-SPA.Api/Contracts/V1/Products/CreateProductRequest.cs
+++ b/Projeto-SPA.Api/Contracts/V1/Products/CreateProductRequest.cs
@@ -1,0 +1,11 @@
+﻿namespace Projeto_SPA.Api.Contracts.V1.Products
+{
+    public class CreateProductRequest
+    {
+        public required string Title { get; set; }
+
+        public decimal Price { get; set; }
+
+        public int CategoryId { get; set; }
+    }
+}

--- a/Projeto-SPA.Api/Contracts/V1/Products/ProductResponse.cs
+++ b/Projeto-SPA.Api/Contracts/V1/Products/ProductResponse.cs
@@ -1,0 +1,13 @@
+﻿namespace Projeto_SPA.Api.Contracts.V1.Products
+{
+    public class ProductResponse
+    {
+        public int Id { get; set; }
+
+        public string Title { get; set; } = null!;
+
+        public decimal Price { get; set; }
+
+        public int CategoryId { get; set; }
+    }
+}

--- a/Projeto-SPA.Api/Contracts/V1/Products/UpdateProductRequest.cs
+++ b/Projeto-SPA.Api/Contracts/V1/Products/UpdateProductRequest.cs
@@ -1,0 +1,11 @@
+﻿namespace Projeto_SPA.Api.Contracts.V1.Products
+{
+    public class UpdateProductRequest
+    {
+        public required string Title { get; set; }
+
+        public decimal Price { get; set; }
+
+        public int CategoryId { get; set; }
+    }
+}

--- a/Projeto-SPA.Api/Endpoints/V1/CategoryEndpoints.cs
+++ b/Projeto-SPA.Api/Endpoints/V1/CategoryEndpoints.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Projeto_SPA.Api.Contracts.V1.Categories;
 using Projeto_SPA.Api.Data;
 
 namespace Projeto_SPA.Api.Endpoints.V1
@@ -11,14 +12,31 @@ namespace Projeto_SPA.Api.Endpoints.V1
 
             map.MapGet("", async (AppDbContext db) =>
             {
-                var result = await db.Categories.ToListAsync();
+                var result = await db.Categories
+                .AsNoTracking()
+                .Select(c => new CategoryResponse
+                { 
+                    Id = c.Id,
+                    Title = c.Title
+                })
+                .ToListAsync();
+
                 return Results.Ok(result);
             });
 
-            map.MapGet("/{id}", async (int id, AppDbContext db) =>
+            map.MapGet("/{id:int}", async (int id, AppDbContext db) =>
             {
-                var result = await db.Categories.FindAsync(id);
-                if(result == null) 
+                var result = await db.Categories
+                    .AsNoTracking()
+                    .Where(c => c.Id == id)
+                    .Select(c => new CategoryResponse
+                    { 
+                        Id = c.Id,
+                        Title = c.Title
+                    })
+                    .FirstOrDefaultAsync();
+
+                if (result == null)
                     return Results.NotFound();
 
                 return Results.Ok(result);

--- a/Projeto-SPA.Api/Endpoints/V1/ProductEndpoints.cs
+++ b/Projeto-SPA.Api/Endpoints/V1/ProductEndpoints.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
+using Projeto_SPA.Api.Contracts.V1.Products;
 using Projeto_SPA.Api.Data;
 
 namespace Projeto_SPA.Api.Endpoints.V1
@@ -8,17 +9,38 @@ namespace Projeto_SPA.Api.Endpoints.V1
     {
         public static void MapProductEndpoints(this WebApplication app)
         {
-            var map = app.MapGroup("api/v1/products");
+            var map = app.MapGroup("/api/v1/products");
 
-            map.MapGet("", async (AppDbContext db) => 
-            { 
-                var result = await db.Products.ToListAsync();
+            map.MapGet("", async (AppDbContext db) =>
+            {
+                var result = await db.Products
+                    .AsNoTracking()
+                    .Select(c => new ProductResponse
+                    {
+                        Id = c.Id,
+                        Title = c.Title,
+                        Price = c.Price,
+                        CategoryId = c.CategoryId
+                    })
+                    .ToListAsync();
+
                 return Results.Ok(result);
             });
 
             map.MapGet("/{id}", async (int id, AppDbContext db) =>
             {
-                var result = await db.Products.FindAsync(id);
+                var result = await db.Products
+                    .AsNoTracking()
+                    .Where(c => c.Id == id)
+                    .Select(c => new ProductResponse
+                    {
+                        Id = c.Id,
+                        Title = c.Title,
+                        Price = c.Price,
+                        CategoryId = c.CategoryId
+                    })
+                    .FirstOrDefaultAsync();
+
                 if (result == null)
                     return Results.NotFound();
 


### PR DESCRIPTION
# PR Title
feat(api): introduce request and response DTOs for categories and products

# Description

## Context
- The API was directly exposing EF Core entities through its endpoints.
- This tightly coupled the HTTP contract to the persistence layer.
- Introduce dedicated request and response models to decouple the API contract from EF Core entities and prepare the system for versioned evolution.

## What was done
- Created `CategoryRequest` and `CategoryResponse` models.
- Created `ProductRequest` and `ProductResponse` models.
- Updated existing read endpoints to return response DTOs instead of EF Core entities.
- Ensured no EF Core entity is returned directly by any current API endpoint.

## How to test
- Run the application locally.
- Open Swagger.
- Test the following endpoints:
  - `GET /api/v1/categories`
  - `GET /api/v1/categories/{id}`
  - `GET /api/v1/products`
  - `GET /api/v1/products/{id}`

## Related issue
Closes #18 

## Notes
- Only read endpoints are covered in this change.
- Create, Update, and Delete operations will be implemented in subsequent issues.
- No validation or authentication is included at this stage.
- The API contract is now decoupled from EF Core entities, preparing the system for future versioned changes.