### PR TITLE
feat(api): introduce standardized ApiResponse wrapper for v1 endpoints

### DIFF
--- a/Projeto-SPA.Api/Endpoints/V1/CategoryEndpoints.cs
+++ b/Projeto-SPA.Api/Endpoints/V1/CategoryEndpoints.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Projeto_SPA.Api.Contracts.V1.Categories;
 using Projeto_SPA.Api.Data;
+using Projeto_SPA.Api.Responses;
 
 namespace Projeto_SPA.Api.Endpoints.V1
 {
@@ -21,7 +22,11 @@ namespace Projeto_SPA.Api.Endpoints.V1
                 })
                 .ToListAsync();
 
-                return Results.Ok(result);
+                return Results.Ok(
+                    new ApiResponse<List<CategoryResponse>>(
+                        result,
+                        "Categories retrivered successfully"
+                    ));
             });
 
             map.MapGet("/{id:int}", async (int id, AppDbContext db) =>
@@ -37,9 +42,17 @@ namespace Projeto_SPA.Api.Endpoints.V1
                     .FirstOrDefaultAsync();
 
                 if (result == null)
-                    return Results.NotFound();
+                    return Results.NotFound(
+                        new ApiResponse<object>(
+                            new[] {"Category not found"},
+                            "Resource not found"
+                        ));
 
-                return Results.Ok(result);
+                return Results.Ok(
+                    new ApiResponse<CategoryResponse>(
+                        result,
+                        "Category retrivered successfully"
+                    ));
             });
         }
     }

--- a/Projeto-SPA.Api/Endpoints/V1/ProductEndpoints.cs
+++ b/Projeto-SPA.Api/Endpoints/V1/ProductEndpoints.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using Projeto_SPA.Api.Contracts.V1.Products;
 using Projeto_SPA.Api.Data;
+using Projeto_SPA.Api.Responses;
 
 namespace Projeto_SPA.Api.Endpoints.V1
 {
@@ -24,7 +25,11 @@ namespace Projeto_SPA.Api.Endpoints.V1
                     })
                     .ToListAsync();
 
-                return Results.Ok(result);
+                return Results.Ok(
+                    new ApiResponse<List<ProductResponse>>(
+                        result,
+                        "Products retrivered successfully"
+                    ));
             });
 
             map.MapGet("/{id}", async (int id, AppDbContext db) =>
@@ -42,9 +47,17 @@ namespace Projeto_SPA.Api.Endpoints.V1
                     .FirstOrDefaultAsync();
 
                 if (result == null)
-                    return Results.NotFound();
+                    return Results.NotFound(
+                        new ApiResponse<object>(
+                            new[] {"Product not found"},
+                            "Resource not found"
+                        ));
 
-                return Results.Ok(result);
+                return Results.Ok(
+                    new ApiResponse<ProductResponse>(
+                        result,
+                        "Product retriverect successfully"
+                    ));
             });
         }
     }

--- a/Projeto-SPA.Api/Responses/ApiResponse.cs
+++ b/Projeto-SPA.Api/Responses/ApiResponse.cs
@@ -1,0 +1,26 @@
+﻿namespace Projeto_SPA.Api.Responses
+{
+    public class ApiResponse<T>
+    {
+        public bool Success { get; set; }
+        public string? Message { get; set; }
+        public T? Data { get; set; }
+        public IEnumerable<string>? Errors { get; set; }
+
+        public ApiResponse(T data, string? message = null)
+        {
+            Success = true;
+            Message = message;
+            Data = data;
+            Errors = null;
+        }
+
+        public ApiResponse(IEnumerable<string> errors, string? message = null)
+        {
+            Success = false;
+            Message = message;
+            Data = default;
+            Errors = errors;
+        }
+    }
+}


### PR DESCRIPTION
# PR Title
feat(api): introduce standardized ApiResponse wrapper for v1 endpoints

# Description

## Context
- The API endpoints were returning raw response objects directly. This resulted in inconsistent response structures and made it harder to standardize success and error responses across the API.
- Introduce a generic `ApiResponse` wrapper to provide a consistent response structure for all API v1 endpoints and prepare the API for future improvements such as centralized error handling and validation responses.

## What was done
- Created a generic `ApiResponse<T>` response wrapper.
- Updated existing v1 endpoints to return responses using `ApiResponse`.
- Standardized success and error response structures across the API.
- Ensured appropriate HTTP status codes are used (`200`, `201`, `204`, `400`, `404`).

## How to test
- Run the application locally.
- Open Swagger.
- Test the following endpoints:
  - `GET /api/v1/categories`
  - `GET /api/v1/categories/{id}`
  - `GET /api/v1/products`
  - `GET /api/v1/products/{id}`
- Verify that responses follow the standardized structure:
  - Success responses contain `success`, `message`, `data`, and `errors`.
  - Error responses contain `success = false` and an appropriate `errors` list.
- Confirm that correct HTTP status codes are returned depending on the scenario.

## Related issue
Closes #19 

## Notes
- This change focuses on response standardization for API v1 endpoints.
- No additional middleware or response factories were introduced to keep the implementation simple for the current stage of the project.