### PR TITLE
feat(api): implement full CRUD for category endpoints

### DIFF
--- a/Projeto-SPA.Api/Contracts/V1/Categories/CreateCategoryRequest.cs
+++ b/Projeto-SPA.Api/Contracts/V1/Categories/CreateCategoryRequest.cs
@@ -1,7 +1,12 @@
-﻿namespace Projeto_SPA.Api.Contracts.V1.Categories
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Projeto_SPA.Api.Contracts.V1.Categories
 {
     public class CreateCategoryRequest
     {
+        [Required(ErrorMessage = "Title is required")]
+        [StringLength(100, MinimumLength = 2,
+            ErrorMessage = "Title must be between 2 and 100 characters")]
         public required string Title { get; set; }
     }
 }

--- a/Projeto-SPA.Api/Contracts/V1/Categories/UpdateCategoryRequest.cs
+++ b/Projeto-SPA.Api/Contracts/V1/Categories/UpdateCategoryRequest.cs
@@ -1,7 +1,12 @@
-﻿namespace Projeto_SPA.Api.Contracts.V1.Categories
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Projeto_SPA.Api.Contracts.V1.Categories
 {
     public class UpdateCategoryRequest
     {
+        [Required(ErrorMessage = "Title is required")]
+        [StringLength(100, MinimumLength = 2,
+            ErrorMessage = "Title must be between 2 and 100 characters")]
         public required string Title { get; set; }
     }
 }

--- a/Projeto-SPA.Api/Endpoints/V1/CategoryEndpoints.cs
+++ b/Projeto-SPA.Api/Endpoints/V1/CategoryEndpoints.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Projeto_SPA.Api.Contracts.V1.Categories;
 using Projeto_SPA.Api.Data;
+using Projeto_SPA.Api.Models;
 using Projeto_SPA.Api.Responses;
 
 namespace Projeto_SPA.Api.Endpoints.V1
@@ -23,9 +24,9 @@ namespace Projeto_SPA.Api.Endpoints.V1
                 .ToListAsync();
 
                 return Results.Ok(
-                    new ApiResponse<List<CategoryResponse>>(
+                    new ApiResponse<IEnumerable<CategoryResponse>>(
                         result,
-                        "Categories retrivered successfully"
+                        "Categories retrieved successfully"
                     ));
             });
 
@@ -51,8 +52,74 @@ namespace Projeto_SPA.Api.Endpoints.V1
                 return Results.Ok(
                     new ApiResponse<CategoryResponse>(
                         result,
-                        "Category retrivered successfully"
+                        "Category retrieved successfully"
                     ));
+            });
+
+            map.MapPost("", async(CreateCategoryRequest request, AppDbContext db) =>
+            {
+                var category = new Category
+                {
+                    Title = request.Title
+                };
+
+                db.Categories.Add(category);
+                await db.SaveChangesAsync();
+
+                var response = new CategoryResponse
+                {
+                    Id = category.Id,
+                    Title = category.Title
+                };
+
+                return Results.Created($"/api/v1/categories/{category.Id}",
+                    new ApiResponse<CategoryResponse>(
+                        response,
+                        "Category created successfully"
+                    ));
+            });
+
+            map.MapPut("/{id:int}", async (int id, UpdateCategoryRequest request, AppDbContext db) =>
+            {
+                var category = await db.Categories.FindAsync(id);
+                if (category == null)
+                    return Results.NotFound(
+                        new ApiResponse<object>(
+                            new[] {"Category not found"},
+                            "Resource not found"
+                        ));
+
+                category.Title = request.Title;
+
+                await db.SaveChangesAsync();
+
+                var response = new CategoryResponse
+                {
+                    Id = category.Id,
+                    Title = category.Title
+                };
+
+                return Results.Ok(
+                    new ApiResponse<CategoryResponse>(
+                        response,
+                        "Category updated successfully"
+                    ));
+            });
+
+            map.MapDelete("/{id:int}", async (int id, AppDbContext db) =>
+            {
+                var category = await db.Categories.FindAsync(id);
+                if(category == null)
+                    return Results.NotFound(
+                        new ApiResponse<object>(
+                            new[] {"Category not found"},
+                            "Resource not found"
+                        ));
+
+                db.Categories.Remove(category);
+                await db.SaveChangesAsync();
+
+                return Results.NoContent();
             });
         }
     }


### PR DESCRIPTION
# PR Title
feat(api): implement full CRUD for category endpoints

# Description

## Context
- The Categories endpoints only supported read operations.
- The API needed full CRUD capabilities to properly manage category resources.

## What was done
- Implemented POST /api/v1/categories to create categories.
- Implemented PUT /api/v1/categories/{id} to update categories.
- Implemented DELETE /api/v1/categories/{id} to remove categories.
- Integrated ApiResponse pattern for consistent responses.

## How to test
- Run the application.
- Open Swagger.
- Test the following endpoints:
  - `POST /api/v1/categories`
  - `PUT /api/v1/categories/{id}`
  - `DELETE /api/v1/categories/{id}`
- Validate that:
  - Categories are created successfully.
  - Categories can be updated.
  - Categories are removed correctly.
  - Responses follow the ApiResponse structure.

## Related issue
Closes #20 

## Notes
- All endpoints follow the ApiResponse response pattern.