### PR TITLE
feat(api): implement full CRUD for product endpoints

### DIFF
--- a/Projeto-SPA.Api/Contracts/V1/Products/CreateProductRequest.cs
+++ b/Projeto-SPA.Api/Contracts/V1/Products/CreateProductRequest.cs
@@ -1,11 +1,20 @@
-﻿namespace Projeto_SPA.Api.Contracts.V1.Products
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Projeto_SPA.Api.Contracts.V1.Products
 {
     public class CreateProductRequest
     {
+        [Required(ErrorMessage = "Title is required")]
+        [StringLength(100, MinimumLength = 2,
+            ErrorMessage = "Title must be between 2 and 100 characters")]
         public required string Title { get; set; }
 
+        [Range(0.01, double.MaxValue,
+            ErrorMessage = "Price must be greater than 0")]
         public decimal Price { get; set; }
 
+        [Range(1, int.MaxValue,
+            ErrorMessage = "CategoryId must be a valid id")]
         public int CategoryId { get; set; }
     }
 }

--- a/Projeto-SPA.Api/Contracts/V1/Products/UpdateProductRequest.cs
+++ b/Projeto-SPA.Api/Contracts/V1/Products/UpdateProductRequest.cs
@@ -1,11 +1,20 @@
-﻿namespace Projeto_SPA.Api.Contracts.V1.Products
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Projeto_SPA.Api.Contracts.V1.Products
 {
     public class UpdateProductRequest
     {
+        [Required(ErrorMessage = "Title is required")]
+        [StringLength(100, MinimumLength = 2,
+            ErrorMessage = "Title must be between 2 and 100 characters")]
         public required string Title { get; set; }
 
+        [Range(0.01, double.MaxValue,
+            ErrorMessage = "Price must be greater than 0")]
         public decimal Price { get; set; }
 
+        [Range(1, int.MaxValue,
+            ErrorMessage = "CategoryId must be a valid id")]
         public int CategoryId { get; set; }
     }
 }

--- a/Projeto-SPA.Api/Endpoints/V1/ProductEndpoints.cs
+++ b/Projeto-SPA.Api/Endpoints/V1/ProductEndpoints.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
+using Projeto_SPA.Api.Contracts.V1.Categories;
 using Projeto_SPA.Api.Contracts.V1.Products;
 using Projeto_SPA.Api.Data;
+using Projeto_SPA.Api.Models;
 using Projeto_SPA.Api.Responses;
 
 namespace Projeto_SPA.Api.Endpoints.V1
@@ -26,38 +28,130 @@ namespace Projeto_SPA.Api.Endpoints.V1
                     .ToListAsync();
 
                 return Results.Ok(
-                    new ApiResponse<List<ProductResponse>>(
+                    new ApiResponse<IEnumerable<ProductResponse>>(
                         result,
-                        "Products retrivered successfully"
+                        "Products retrieved successfully"
                     ));
             });
 
-            map.MapGet("/{id}", async (int id, AppDbContext db) =>
+            map.MapGet("/{id:int}", async (int id, AppDbContext db) =>
             {
                 var result = await db.Products
                     .AsNoTracking()
-                    .Where(c => c.Id == id)
-                    .Select(c => new ProductResponse
+                    .Where(p => p.Id == id)
+                    .Select(p => new ProductResponse
                     {
-                        Id = c.Id,
-                        Title = c.Title,
-                        Price = c.Price,
-                        CategoryId = c.CategoryId
+                        Id = p.Id,
+                        Title = p.Title,
+                        Price = p.Price,
+                        CategoryId = p.CategoryId
                     })
                     .FirstOrDefaultAsync();
 
                 if (result == null)
                     return Results.NotFound(
                         new ApiResponse<object>(
-                            new[] {"Product not found"},
+                            new[] { "Product not found" },
                             "Resource not found"
                         ));
 
                 return Results.Ok(
                     new ApiResponse<ProductResponse>(
                         result,
-                        "Product retriverect successfully"
+                        "Product retrieved successfully"
                     ));
+            });
+
+            map.MapPost("", async (CreateProductRequest request, AppDbContext db) =>
+            {
+                var categoryExists = await db.Categories
+                    .AnyAsync(c => c.Id == request.CategoryId);
+                if(!categoryExists)
+                    return Results.BadRequest(
+                        new ApiResponse<object>(
+                            new[] { "Category does not exist" },
+                            "Validation failed"
+                        ));
+
+                var product = new Product
+                {
+                    Title = request.Title,
+                    Price = request.Price,
+                    CategoryId = request.CategoryId
+                };
+
+                db.Products.Add(product);
+                await db.SaveChangesAsync();
+
+                var response = new ProductResponse
+                {
+                    Id = product.Id,
+                    Title = product.Title,
+                    Price = product.Price,
+                    CategoryId = product.CategoryId
+                };
+
+                return Results.Created($"/api/v1/products/{response.Id}",
+                    new ApiResponse<ProductResponse>(
+                        response,
+                        "Product created successfully"
+                    ));
+            });
+
+            map.MapPut("/{id:int}", async (int id, UpdateProductRequest request, AppDbContext db) =>
+            {
+                var categoryExists = await db.Categories
+                    .AnyAsync(c => c.Id == request.CategoryId);
+                if (!categoryExists)
+                    return Results.BadRequest(
+                        new ApiResponse<object>(
+                            new[] { "Category does not exist" },
+                            "Validation failed"
+                        ));
+
+                var product = await db.Products.FindAsync(id);
+                if (product == null)
+                    return Results.NotFound(
+                        new ApiResponse<object>(
+                            new[] { "Product not found" },
+                            "Resource not found"
+                        ));
+
+                product.Title = request.Title;
+                product.Price = request.Price;
+                product.CategoryId = request.CategoryId;
+
+                await db.SaveChangesAsync();
+
+                var response = new ProductResponse
+                {
+                    Id = product.Id,
+                    Title = product.Title,
+                    Price = product.Price,
+                    CategoryId = product.CategoryId
+                };
+
+                return Results.Ok(
+                    new ApiResponse<ProductResponse>(
+                        response,
+                        "Product updated successfully"
+                    ));
+            });
+
+            map.MapDelete("/{id:int}", async (int id, AppDbContext db) =>
+            {
+                var product = await db.Products.FindAsync(id);
+                if (product == null)
+                    return Results.NotFound(
+                        new ApiResponse<object>(
+                            new[] { "Product not found" },
+                            "Resource not found"
+                    ));
+
+                db.Products.Remove(product);
+                await db.SaveChangesAsync();
+
+                return Results.NoContent();
             });
         }
     }


### PR DESCRIPTION
# PR Title
feat(api): implement full CRUD for product endpoints

# Description

## Context
- The Products endpoints previously supported only read operations.
- Full CRUD operations were required to allow complete product management.

## What was done
- Implemented POST /api/v1/products to create products.
- Implemented PUT /api/v1/products/{id} to update products.
- Implemented DELETE /api/v1/products/{id} to remove products.
- Ensured responses follow the ApiResponse pattern.

## How to test
- Run the application.
- Open Swagger.
- Test the following endpoints:
  - `POST /api/v1/products`
  - `PUT /api/v1/products/{id}`
  - `DELETE /api/v1/products/{id}`
- Validate that:
  - Products are created successfully.
  - Products are created successfully.
  - Products can be deleted.
  - Products can be deleted.

## Related issue
Closes #21 

## Notes
- All responses use the standardized ApiResponse wrapper.