### PR TITLE
refactor(ui): consume api v1 via httpclient instead of direct dbcontext access

### DIFF
--- a/Projeto-SPA-Blazor.sln
+++ b/Projeto-SPA-Blazor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.13.35931.197
+# Visual Studio Version 18
+VisualStudioVersion = 18.3.11520.95 d18.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Projeto-SPA-Blazor", "Projeto-SPA-Blazor\Projeto-SPA-Blazor.csproj", "{927DFAC9-4048-4826-A64B-CA0A5D89CBF2}"
 EndProject

--- a/Projeto-SPA-Blazor/Pages/Categories/CreateCategory.razor
+++ b/Projeto-SPA-Blazor/Pages/Categories/CreateCategory.razor
@@ -1,31 +1,69 @@
 ﻿@page "/categories/create"
+@using Projeto_SPA_Blazor.Contracts.V1.Category
+@using Projeto_SPA_Blazor.Services
 @inject NavigationManager navigationManager
+@inject CategoryService CategoryService
 
 <PageTitle>Create Category</PageTitle>
 
 <h1>Create Category</h1>
 
-<EditForm Model="model" OnValidSubmit="HandleSubmitAysnc">
-
-	<DataAnnotationsValidator />
-	<ValidationSummary />
+<EditForm Model="model" OnValidSubmit="HandleSubmitAsync">
 
 	<div class="mb-3">
 		<label for="Title" class="form-label"><b>Title</b></label>
 		<InputText id="Title" type="text" class="form-control" @bind-Value=@model.Title/>
 	</div>
 
+	@if(!string.IsNullOrEmpty(message))
+	{
+		<div class="alert alert-info">@message</div>
+	}
+
+	@if(errors.Any())
+	{
+		<div class="alert alert-danger">
+			<ul>
+				@foreach(var error in errors)
+				{
+					<li>
+						@error
+					</li>
+				}
+			</ul>
+		</div>
+	}
+
 	<button class="btn btn-success" type="submit"><b>Create</b></button>
+	<a class="btn btn-primary" href="/categories"><b>Cancel</b></a>
 </EditForm>
 
 @code
 {
-	Category model = new();
+	CreateCategoryRequest model = new();
 
-	async Task HandleSubmitAysnc()
+	List<string> errors = new();
+	string? message;
+
+	async Task HandleSubmitAsync()
 	{
-		await context.Categories.AddAsync(model);
-		await context.SaveChangesAsync();
+		errors.Clear();
+		message = null;
+
+		var request = await CategoryService.CreateAsync(model);
+
+		if (request is null)
+		{
+			errors.Add("Server error.");
+			return;
+		}
+
+		if (!request.Success)
+		{
+			errors = request.Errors?.ToList() ?? new();
+			message = request.Message;
+			return;
+		}
 
 		navigationManager.NavigateTo("/categories");
 	}

--- a/Projeto-SPA-Blazor/Pages/Categories/DeleteCategory.razor
+++ b/Projeto-SPA-Blazor/Pages/Categories/DeleteCategory.razor
@@ -1,5 +1,8 @@
 ﻿@page "/categories/delete/{id:int}"
+@using Projeto_SPA_Blazor.Contracts.V1.Category
+@using Projeto_SPA_Blazor.Services
 @inject NavigationManager navigationManager
+@inject CategoryService CategoryService
 
 <PageTitle>Delete Category</PageTitle>
 
@@ -7,15 +10,27 @@
 
 <EditForm Model="model" OnValidSubmit="HandleSubmitAsync">
 
-	<DataAnnotationsValidator />
-	<ValidationSummary />
-
 	<div class="mb-3">
 		<label for="Title" class="form-label"><b>Title</b></label>
 		<InputText readonly id="Title" class="form-control" type="text" @bind-Value=@model.Title/>
 	</div>
 
+	@if(errors.Any())
+	{
+		<div class="alert alert-danger">
+			<ul>
+				@foreach(var error in errors)
+				{
+					<li>
+						@error
+					</li>
+				}
+			</ul>
+		</div>
+	}
+
 	<button class="btn btn-danger" type="submit"><b>Delete</b></button>
+	<a class="btn btn-primary" href="/categories"><b>Cancel</b></a>
 </EditForm>
 
 @code
@@ -23,23 +38,34 @@
 	[Parameter]
 	public int id { get; set; }
 
-	Category? model = new();
+	CategoryResponse model = new();
+
+	List<string> errors = new();
 
 	protected override async Task OnInitializedAsync()
 	{
-		model = await context.Categories.FindAsync(id);
-		if(model is null)
+		var response = await CategoryService.GetAsync(id);
+
+		if(response is null || !response.Success || response.Data is null)
+		{
 			navigationManager.NavigateTo("/categories");
+			return;
+		}
+
+		model.Title = response.Data.Title;
 	}
 
 	async Task HandleSubmitAsync()
 	{
-		var categorytoDelete = await context.Categories.FindAsync(id);
-		if (categorytoDelete is null)
-			return;
+		errors.Clear();
 
-		context.Categories.Remove(categorytoDelete);
-		await context.SaveChangesAsync();
+		var request = await CategoryService.DeleteAsync(id);
+
+		if(!request)
+		{
+			errors.Add("Failed to delete category.");
+			return;
+		}
 
 		navigationManager.NavigateTo("/categories");
 	}

--- a/Projeto-SPA-Blazor/Pages/Categories/Index.razor
+++ b/Projeto-SPA-Blazor/Pages/Categories/Index.razor
@@ -1,4 +1,7 @@
 ﻿@page "/categories"
+@using Projeto_SPA_Blazor.Contracts.V1.Category
+@using Projeto_SPA_Blazor.Services
+@inject CategoryService CategoryService
 
 <PageTitle>Categories</PageTitle>
 
@@ -10,7 +13,7 @@
 	<thead>
 		<tr>
 			<th>Id</th>
-			<th>Name</th>
+			<th>Title</th>
 			<th>Actions</th>
 		</tr>
 	</thead>
@@ -31,10 +34,15 @@
 
 @code 
 {
-	List<Category> categories = new();
+	List<CategoryResponse> categories = new();
 
 	protected override async Task OnInitializedAsync()
 	{
-		categories = await context.Categories.AsNoTracking().ToListAsync();
+		var response = await CategoryService.GetAllAsync();
+
+		if (response is not null && response.Success)
+		{
+			categories = response.Data!;
+		}
 	}
 }

--- a/Projeto-SPA-Blazor/Pages/Categories/UpdateCategory.razor
+++ b/Projeto-SPA-Blazor/Pages/Categories/UpdateCategory.razor
@@ -1,4 +1,7 @@
 ﻿@page "/categories/update/{id:int}"
+@using Projeto_SPA_Blazor.Contracts.V1.Category
+@using Projeto_SPA_Blazor.Services
+@inject CategoryService CategoryService
 @inject NavigationManager navigationManager
 
 <PageTitle>Update Category</PageTitle>
@@ -7,15 +10,32 @@
 
 <EditForm Model="model" OnValidSubmit="HandleSubmitAsync">
 
-	<DataAnnotationsValidator />
-	<ValidationSummary />
-
 	<div class="mb-3"> 
 		<label for="Title" class="form-label"><b>Title</b></label>
 		<InputText id="Title" type="text" class="form-control" @bind-Value=@model.Title/>
 	</div>
 
+	@if(!string.IsNullOrEmpty(message))
+	{
+		<div class="alert alert-info">@message</div>	
+	}
+
+	@if(errors.Any())
+	{
+		<div class="alert alert-danger">
+			<ul>
+				@foreach(var error in errors)
+				{
+					<li>
+						@error
+					</li>
+				}
+			</ul>
+		</div>
+	}
+
 	<button class="btn btn-success" type="submit"><b>Update</b></button>
+	<a class="btn btn-primary" href="/categories"><b>Cancel</b></a>
 </EditForm>
 
 @code
@@ -23,24 +43,43 @@
 	[Parameter]
 	public int id { get; set; }
 
-	Category? model = new();
+	UpdateCategoryRequest model = new();
+
+	List<string> errors = new();
+	string? message;
 
 	protected override async Task OnInitializedAsync()
 	{
-		model = await context.Categories.FindAsync(id);
-		if(model is null)
+		var response = await CategoryService.GetAsync(id);
+
+		if(response is null || !response.Success || response.Data is null)
+		{
 			navigationManager.NavigateTo("/categories");
+			return;
+		}
+
+		model.Title = response.Data.Title;
 	}
 
 	async Task HandleSubmitAsync()
 	{
-		var updatedCategory = await context.Categories.FindAsync(id);
-		if (updatedCategory is null)
+		errors.Clear();
+		message = null;
+
+		var request = await CategoryService.UpdateAsync(id, model);
+
+		if(request is null)
+		{
+			errors.Add("Server error.");
 			return;
+		}
 
-		updatedCategory.Title = model!.Title;
-
-		await context.SaveChangesAsync();
+		if(!request.Success)
+		{
+			errors = request.Errors?.ToList() ?? new();
+			message = request.Message;
+			return;
+		}
 
 		navigationManager.NavigateTo("/categories");
 	}

--- a/Projeto-SPA-Blazor/Pages/Products/CreateProduct.razor
+++ b/Projeto-SPA-Blazor/Pages/Products/CreateProduct.razor
@@ -1,14 +1,15 @@
 ﻿@page "/products/create"
-@inject NavigationManager _navigations
+@using Projeto_SPA_Blazor.Contracts.V1.Category
+@using Projeto_SPA_Blazor.Contracts.V1.Product
+@using Projeto_SPA_Blazor.Services
+@inject NavigationManager navigationManager
+@inject ProductService ProductService
 
 <PageTitle>Create Product</PageTitle>
 
 <h1>Create Product</h1>
 
 <EditForm Model="model" OnValidSubmit="HandleSubmitAsync">
-
-	<DataAnnotationsValidator />
-	<ValidationSummary />
 
 	<div class="mb-3">
 		<label for="Title" class="form-label"><b>Title</b></label>
@@ -20,39 +21,59 @@
 	</div>
 	<div class="mb-3">
 		<label for="CategoryId" class="form-label"><b>Category</b></label>
-		<InputSelect class="form-control" id="CategoryId" @bind-Value=@model.CategoryId>
-			@foreach(var category in categories)
-			{
-				<option value="@category.Id">@category.Title</option>
-			}
-		</InputSelect>
+		<InputNumber class="form-control" type="number" id="CategoryId" @bind-Value=@model.CategoryId />
 	</div>
 
+	@if(!string.IsNullOrEmpty(message))
+	{
+		<div class="alert alert-info">@message</div>
+	}
+
+	@if (errors.Any())
+	{
+		<div class="alert alert-danger">
+			<ul>
+				@foreach (var error in errors)
+				{
+					<li>
+						@error
+					</li>
+				}
+			</ul>
+		</div>
+	}
+
 	<button class="btn btn-success" type="submit"><b>Create</b></button>
+	<a class="btn btn-primary" href="/products"><b>Cancel</b></a>
 </EditForm>
 
 @code
 {
-	Product model = new();
-	List<Category> categories = new();
-	string? errorMessage = null;
+	CreateProductRequest model = new();
 
-	protected override async Task OnInitializedAsync()
-	{
-		categories = await context.Categories.AsNoTracking().ToListAsync();
-	}
+	List<string> errors = new();
+	string? message;
 
 	async Task HandleSubmitAsync()
 	{
-		try
+		errors.Clear();
+		message = null;
+
+		var request = await ProductService.CreateAsync(model);
+
+		if(request is null)
 		{
-			await context.Products.AddAsync(model);
-			await context.SaveChangesAsync();
-			_navigations.NavigateTo("/products");
-		}
-		catch (Exception ex)
+			errors.Add("Server error.");
+			return;
+		};
+
+		if (!request.Success)
 		{
-			errorMessage = ex.Message;
+			errors = request.Errors?.ToList() ?? new();
+			message = request.Message;
+			return;
 		}
+
+		navigationManager.NavigateTo("/products");
 	}
 }

--- a/Projeto-SPA-Blazor/Pages/Products/DeleteProduct.razor
+++ b/Projeto-SPA-Blazor/Pages/Products/DeleteProduct.razor
@@ -1,14 +1,14 @@
 ﻿@page "/products/delete/{id:int}"
-@inject NavigationManager navigations
+@using Projeto_SPA_Blazor.Contracts.V1.Product
+@using Projeto_SPA_Blazor.Services
+@inject NavigationManager navigationManager
+@inject ProductService ProductService
 
 <PageTitle>Delete Product</PageTitle>
 
 <h1>Delete: @model!.Title</h1>
 
 <EditForm Model="model" OnValidSubmit="HandleSubmitAsync">
-
-	<DataAnnotationsValidator />
-	<ValidationSummary />
 
 	<div class="mb-3">
 		<label for="Title" class="form-label"><b>Title</b></label>
@@ -19,6 +19,20 @@
 		<InputNumber readonly id="Price" type="number" class="form-control" @bind-Value=@model.Price/>
 	</div>
 
+	@if(errors.Any())
+	{
+		<div class="alert alert-danger">
+			<ul>
+				@foreach(var error in errors)
+				{
+					<li>
+						@error
+					</li>
+				}
+			</ul>
+		</div>
+	}
+
 	<button class="btn btn-danger" type="submit"><b>Delete</b></button>
 	<a class="btn btn-primary" href="/products"><b>Cancel</b></a>
 </EditForm>
@@ -28,24 +42,37 @@
 	[Parameter]
 	public int id { get; set; }
 
-	Product? model = new();
+	ProductResponse model = new();
+
+	List<string> errors = new();
 
 	protected override async Task OnInitializedAsync()
 	{
-		model = await context.Products.FindAsync(id);
-		if(model is null)
-			navigations.NavigateTo("/products");
+		var response = await ProductService.GetAsync(id);
+
+		if(response is null || !response.Success || response.Data is null)
+		{
+			navigationManager.NavigateTo("/products");
+			return;
+		}
+
+		model.Title = response.Data.Title;
+		model.Price = response.Data.Price;
+		model.CategoryId = response.Data.CategoryId;
 	}
 
 	async Task HandleSubmitAsync()
 	{
-		var productToDelete = await context.Products.FindAsync(id);
-		if (productToDelete is not null)
+		errors.Clear();
+
+		var request = await ProductService.DeleteAsync(id);
+
+		if(!request)
 		{
-			context.Products.Remove(productToDelete);
-			await context.SaveChangesAsync();
+			errors.Add("Failed to delete Product.");
+			return;
 		}
 
-		navigations.NavigateTo("/products");
+		navigationManager.NavigateTo("/products");
 	}
 }

--- a/Projeto-SPA-Blazor/Pages/Products/Index.razor
+++ b/Projeto-SPA-Blazor/Pages/Products/Index.razor
@@ -1,5 +1,8 @@
 ﻿@page "/products"
 @using System.Globalization
+@using Projeto_SPA_Blazor.Contracts.V1.Product
+@using Projeto_SPA_Blazor.Services
+@inject ProductService ProductService
 
 <PageTitle>Products</PageTitle>
 
@@ -24,7 +27,7 @@
 				<td>@product.Id</td>
 				<td>@product.Title</td>
 				<td>@product.Price.ToString("C", new CultureInfo("pt-BR"))</td>
-				<td>@product.Category.Title</td>
+				<td>@product.CategoryId</td>
 				<td>
 					<a class="btn btn-primary" href="/products/update/@product.Id"><b>Update</b></a>
 					<a class="btn btn-danger" href="/products/delete/@product.Id"><b>Delete</b></a>
@@ -36,10 +39,15 @@
 
 @code
 {
-	List<Product> products = new();
+	List<ProductResponse> products = new();
 
 	protected override async Task OnInitializedAsync()
 	{
-		products = await context.Products.Include(p=> p.Category).AsNoTracking().ToListAsync();
+		var response = await ProductService.GetAllAsync();
+
+		if (response is not null && response.Success)
+		{
+			products = response.Data!;
+		}
 	}
 }

--- a/Projeto-SPA-Blazor/Pages/Products/UpdateProduct.razor
+++ b/Projeto-SPA-Blazor/Pages/Products/UpdateProduct.razor
@@ -1,14 +1,14 @@
 ﻿@page "/products/update/{id:int}"
-@inject NavigationManager navigations
+@using Projeto_SPA_Blazor.Contracts.V1.Product
+@using Projeto_SPA_Blazor.Services
+@inject NavigationManager navigationManager
+@inject ProductService ProductService
 
 <PageTitle>Update Product</PageTitle>
 
 <h1>Update: @model.Title</h1>
 
 <EditForm Model="model" OnValidSubmit="HandleSubmitAsync">
-
-	<DataAnnotationsValidator />
-	<ValidationSummary />
 
 	<div class="mb-3">
 		<label for="Title" class="form-label"><b>Title</b></label>
@@ -19,16 +19,31 @@
 		<InputNumber id="Price" class="form-control" type="number" @bind-Value=@model.Price/>
 	</div>
 	<div class="mb-3">
-		<label for="CategoryId" class="form-label"><b>Title</b>Category</label>
-		<InputSelect id="CategoryId" class="form-control" @bind-Value=@model.CategoryId>
-			@foreach(var category in categories)
-			{
-				<option value="@category.Id">@category.Title</option>
-			}
-		</InputSelect>
+		<label for="CategoryId" class="form-label"><b>Category</b></label>
+		<InputNumber id="CategoryId" class="form-control" type="number" @bind-Value=@model.CategoryId />
 	</div>
 
+	@if(!string.IsNullOrEmpty(message))
+	{
+		<div class="alert alert-info">@message</div>
+	}
+
+	@if(errors.Any())
+	{
+		<div class="alert alert-danger">
+			<ul>
+				@foreach (var error in errors)
+				{
+					<li>
+						@error
+					</li>
+				}
+			</ul>
+		</div>
+	}
+
 	<button class="btn btn-success" type="submit"><b>Update</b></button>
+	<a class="btn btn-primary" href="/products"><b>Cancel</b></a>
 </EditForm>
 
 @code
@@ -36,32 +51,46 @@
 	[Parameter]
 	public int id { get; set; }
 
-	Product model = new();
-	List<Category> categories = new();
+	UpdateProductRequest model = new();
+
+	List<string> errors = new();
+	string? message;
 
 	protected override async Task OnInitializedAsync()
 	{
-		categories = await context.Categories.AsNoTracking().ToListAsync();
+		var response = await ProductService.GetAsync(id);
 
-		var productFromDb = await context.Products.FindAsync(id);
-		if(productFromDb != null)
-			model = productFromDb;
-		else
-			navigations.NavigateTo("/products");
+		if(response is null || !response.Success || response.Data is null)
+		{
+			navigationManager.NavigateTo("/products");
+			return;
+		}
+
+		model.Title = response.Data.Title;
+		model.Price = response.Data.Price;
+		model.CategoryId = response.Data.CategoryId;
 	}
 
 	async Task HandleSubmitAsync()
 	{
-		var productUpdated = await context.Products.FindAsync(id);
-		if (productUpdated is null)
+		errors.Clear();
+		message = null;
+
+		var request = await ProductService.UpdateAsync(id, model);
+
+		if(request is null)
+		{
+			errors.Add("Server error.");
 			return;
+		}
 
-		productUpdated.Title = model.Title;
-		productUpdated.Price = model.Price;
-		productUpdated.CategoryId = model.CategoryId;
+		if (!request.Success)
+		{
+			errors = request.Errors?.ToList() ?? new();
+			message = request.Message;
+			return;
+		}
 
-		await context.SaveChangesAsync();
-
-		navigations.NavigateTo("/products");
+		navigationManager.NavigateTo("/products");
 	}
 }

--- a/Projeto-SPA-Blazor/Pages/_Host.cshtml
+++ b/Projeto-SPA-Blazor/Pages/_Host.cshtml
@@ -1,0 +1,27 @@
+﻿@page "/"
+@namespace Projeto_SPA_Blazor.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="~/" />
+
+    <title>Projeto-SPA-Blazor</title>
+
+    <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
+    <link href="css/site.css" rel="stylesheet" />
+    <link href="Projeto-SPA-Blazor.styles.css" rel="stylesheet" />
+
+</head>
+
+<body>
+
+    <component type="typeof(App)" render-mode="ServerPrerendered" />
+
+    <script src="_framework/blazor.server.js"></script>
+
+</body>
+</html>

--- a/Projeto-SPA-Blazor/Pages/_Host.cshtml.cs
+++ b/Projeto-SPA-Blazor/Pages/_Host.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Projeto_SPA_Blazor.Pages
+{
+    public class _HostModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Projeto-SPA-Blazor/appsettings.json
+++ b/Projeto-SPA-Blazor/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ApiSettings": {
-    "BaseUrl": "https://localhost:5001"
+    "BaseUrl": "http://localhost:5295"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
# PR Title
refactor(ui): consume api v1 via httpclient instead of direct dbcontext access

# Description

## Context
- Razor components were directly accessing the database via DbContext, violating separation of concerns.
- The application needed to consume the API as the single source of truth, aligning with API-first architecture.

## What was done
- Replaced all direct DbContext usage in Razor components with HTTP calls to `/api/v1` endpoints.
- Refactored all CRUD operations (Create, Read, Update, Delete) to be performed via API.
- Adapted Delete operations to handle `204 NoContent` responses.
- Implemented error and message on API responses.

## How to test
- Run both API and Blazor application.
- Run both API and Blazor application.

Test CRUD operations:
- Create a new category/product.
  → Should be created and redirect to list page.
- Update an existing category/product.
  → Should persist changes and redirect.
- Update an existing category/product.
  → Should persist changes and redirect.

Validate:
- No direct database access exists in Razor components.
- All operations are executed via HTTP.
- Error messages are displayed correctly when API returns failure.
- Application remains fully functional using only API.

## Related issue
Closes #25 

## Notes
-  Delete operations use HTTP status (`204 NoContent`) instead of `ApiResponse`, handled via boolean result in frontend.
- This refactor prepares the application for future API standardization and decoupled architecture.